### PR TITLE
[WIP] Do not connect clien until actually needed

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -143,17 +143,17 @@ func (c *Client) WithQueueDeclareSettings(s connection.QueueDeclareSettings) *Cl
 	return c
 }
 
-// WithTimeout will set the client timeout used when publishing messages.
-func (c *Client) WithTimeout(t time.Duration) *Client {
-	c.Timeout = t
-
-	return c
-}
-
 // WithConsumeSettings will set the settings used when consuming in the client
 // globally.
 func (c *Client) WithConsumeSettings(s connection.ConsumeSettings) *Client {
 	c.consumeSettings = s
+
+	return c
+}
+
+// WithTimeout will set the client timeout used when publishing messages.
+func (c *Client) WithTimeout(t time.Duration) *Client {
+	c.Timeout = t
 
 	return c
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -40,7 +40,13 @@ func TestClientConfig(t *testing.T) {
 	NotEqual(t, certClient, nil)
 
 	ac := amqp.Config{}
-	acClient := New(url).WithDialConfig(ac)
+	qdSettings := connection.QueueDeclareSettings{}
+	cSettings := connection.ConsumeSettings{}
+
+	acClient := New(url).WithDialConfig(ac).
+		WithQueueDeclareSettings(qdSettings).
+		WithConsumeSettings(cSettings).
+		WithTimeout(2500 * time.Millisecond)
 
 	NotEqual(t, acClient, nil)
 }

--- a/examples/tls-server/main.go
+++ b/examples/tls-server/main.go
@@ -51,7 +51,7 @@ func handleClientUsage(ctx context.Context, rw *server.ResponseWriter, d amqp.De
 		CA:   "client/cacert.pem",
 	}
 
-	c := client.New("amqps://guest:guest@localhost:5671/", cert)
+	c := client.New("amqps://guest:guest@localhost:5671/").WithTLS(cert)
 
 	request := client.NewRequest("hello_world").WithStringBody("Sent with client")
 	response, err := c.Send(request)


### PR DESCRIPTION
Minor changes to the client as a first step to fix how `New()` is used.

Closes #11, closes #13