### PR TITLE
Simplify client request/response

### DIFF
--- a/client/middleware.go
+++ b/client/middleware.go
@@ -1,6 +1,8 @@
 package client
 
-import "github.com/streadway/amqp"
+import (
+	"github.com/streadway/amqp"
+)
 
 // SendFunc represents the function that Send does. It takes a Request as input
 // and returns a delivery and an error.

--- a/client/request.go
+++ b/client/request.go
@@ -19,6 +19,10 @@ type Request struct {
 	// Body is the byte slice that will be sent as the body for the request.
 	Body []byte
 
+	// ContentType is the content type of the rquest data. This defaults to
+	// text/plain but should be set appropriate to the content.
+	ContentType string
+
 	// Routing key is the routing key that will be used in the amqp.Publishing
 	// request.
 	RoutingKey string
@@ -50,8 +54,9 @@ type Request struct {
 // will use the content type "text/plain" and always wait for reply.
 func NewRequest(rk string) *Request {
 	r := Request{
+		ContentType: "text/plain",
 		RoutingKey:  rk,
-		Headers:     amqp.Table{"ContentType": "text/plain"},
+		Headers:     amqp.Table{},
 		Reply:       true,
 		middlewares: []MiddlewareFunc{},
 	}
@@ -92,7 +97,7 @@ func (r *Request) WithResponse(wr bool) *Request {
 // request. This value will bee set as the ContentType in the amqp.Publishing
 // type but also preserved as a header value.
 func (r *Request) WithContentType(ct string) *Request {
-	r.Headers["ContentType"] = ct
+	r.ContentType = ct
 
 	return r
 }

--- a/server/bindings_test.go
+++ b/server/bindings_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/bombsimon/amqp-rpc/client"
+	"github.com/bombsimon/amqp-rpc/testhelpers"
 	"github.com/streadway/amqp"
 	. "gopkg.in/go-playground/assert.v1"
 )
@@ -27,9 +28,9 @@ func TestFanout(t *testing.T) {
 	s2.Bind(FanoutBinding("fanout-exchange", fanoutHandler))
 	s3.Bind(FanoutBinding("fanout-exchange", fanoutHandler))
 
-	stop1 := startServer(s1)
-	stop2 := startServer(s2)
-	stop3 := startServer(s3)
+	stop1 := testhelpers.StartServer(s1)
+	stop2 := testhelpers.StartServer(s2)
+	stop3 := testhelpers.StartServer(s3)
 	defer stop1()
 	defer stop2()
 	defer stop3()
@@ -67,7 +68,7 @@ func TestTopic(t *testing.T) {
 		wasCalled["baz.*"] <- string(d.Body)
 	}))
 
-	stop := startServer(s)
+	stop := testhelpers.StartServer(s)
 	defer stop()
 
 	cases := []struct {
@@ -125,7 +126,7 @@ func TestHeaders(t *testing.T) {
 
 	s.Bind(HeadersBinding(h, handler))
 
-	stop := startServer(s)
+	stop := testhelpers.StartServer(s)
 	defer stop()
 
 	// Ensure 'somewhere.*' matches 'somewhere.there'.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -28,7 +28,7 @@ func TestSendWithReply(t *testing.T) {
 		fmt.Fprintf(rw, "Got message: %s", d.Body)
 	}))
 
-	stop := startServer(s)
+	stop := testhelpers.StartServer(s)
 	defer stop()
 
 	c := client.New(url)
@@ -61,7 +61,7 @@ func TestMiddleware(t *testing.T) {
 		fmt.Fprint(rw, "this is not allowed")
 	}))
 
-	stop := startServer(s)
+	stop := testhelpers.StartServer(s)
 	defer stop()
 
 	c := client.New(url)
@@ -104,7 +104,7 @@ func TestReconnect(t *testing.T) {
 		fmt.Fprintf(rw, "Got message: %s", d.Body)
 	}))
 
-	stop := startServer(s)
+	stop := testhelpers.StartServer(s)
 	defer stop()
 	c := client.New(url)
 
@@ -118,21 +118,5 @@ func TestReconnect(t *testing.T) {
 		conn.Close()
 
 		Equal(t, reply.Body, []byte(fmt.Sprintf("Got message: %s", message)))
-	}
-}
-
-func startServer(s *RPCServer) func() {
-	done := make(chan struct{})
-
-	go func() {
-		s.ListenAndServe()
-		close(done)
-	}()
-
-	time.Sleep(50 * time.Millisecond)
-
-	return func() {
-		s.Stop()
-		<-done
 	}
 }

--- a/testhelpers/server.go
+++ b/testhelpers/server.go
@@ -1,0 +1,27 @@
+package testhelpers
+
+import "time"
+
+// The interface is used to avoid circular imports in tests.
+type serverer interface {
+	ListenAndServe()
+	Stop()
+}
+
+// StartServer will start the server s async and then return a function that
+// can be used to stop the server.
+func StartServer(s serverer) func() {
+	done := make(chan struct{})
+
+	go func() {
+		s.ListenAndServe()
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	return func() {
+		s.Stop()
+		<-done
+	}
+}


### PR DESCRIPTION
- Implement timeout on both Request and Client.

- Removes the publishingRequestMessages struct in favor of using the
Request.

- Use pointers to the response delivery and the Request to prevent
unnecessary copying.

- Never return from Send() until the request has been published, even
when a reply is unwanted. This way, if the client is used within a
HandlerFunc we won't shutdown the server until the client has finished
publishing the request.