### PR TITLE
Add support to create a new ResponseWriter with own Publishing. 

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -18,6 +18,13 @@ type ResponseWriter struct {
 	immediate  bool
 }
 
+// NewResponseWriter will create a new response writer with given amqp.Publishing.
+func NewResponseWriter(p *amqp.Publishing) *ResponseWriter {
+	return &ResponseWriter{
+		publishing: p,
+	}
+}
+
 // Write will write the response Body of the amqp.Publishing.
 // It is safe to call Write multiple times.
 func (rw *ResponseWriter) Write(p []byte) (int, error) {


### PR DESCRIPTION
Useful if users needs mock.

Seen this use case when developing custom middleware or when testing the handler func passed to an endpoint. Example:

```go
func Handler(c context.Context, rw *amqprpc.ResponseWriter, d amqp.Delivery) {
    if _, ok := d.Headers["foo"].(string); ok {
        r := Custom(d.Body)

        fmt.Fprintf(rw, r)
        return
    }

    fmt.Fprintf(rw, "not ok")
}

func Custom(b []byte) string {
    return "ok"
}
```

Test if handler works:
```go
func TestHeadercheck(t *testing.T) {
    rw := amqprpc.NewResponseWriter(&amqp.Publishing{})
    h := amqp.Table{"foo": "bar"}

    Handler(context.Background(), rw, amqp.Delivery{Body: []byte("bar"), Headers: h})

    Equal(t, string(rw.Body), "ok")
}
```