### PR TITLE
Add support for graceful shutdown to client. Closes #22

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -128,7 +128,10 @@ func TestGracefulShutdown(t *testing.T) {
 
 	c.Stop()
 
+	// We should have a new synx.Once and reconnect after a disconnect.
 	time.Sleep(50 * time.Millisecond)
 
-	Equal(t, c.publisherRunning, false)
+	r, err = c.Send(NewRequest("myqueue"))
+	Equal(t, err, nil)
+	Equal(t, string(r.Body), "hello")
 }

--- a/connection.go
+++ b/connection.go
@@ -1,7 +1,20 @@
 package amqprpc
 
 import (
+	"errors"
+
 	"github.com/streadway/amqp"
+)
+
+var (
+	// ErrUnexpectedConnClosed is returned by ListenAndServe() if the server
+	// shuts down without calling Stop() and if AMQP does not give an error
+	// when said shutdown happens.
+	ErrUnexpectedConnClosed = errors.New("unexpected connection close without specific error")
+
+	// ErrTimeout is an error returned when a client request does not
+	// receive a response within the client timeout duration.
+	ErrTimeout = errors.New("request timed out")
 )
 
 // ExchangeDeclareSettings is the settings that will be used when a handler
@@ -41,4 +54,29 @@ type ConsumeSettings struct {
 type PublishSettings struct {
 	Mandatory bool
 	Immediate bool
+}
+
+func monitorChannels(stopChan chan struct{}, connectionChannels []chan *amqp.Error) error {
+	result := make(chan error)
+
+	// Setup monitoring for connection channels, can be several connections.
+	// The first one closed will yield the error.
+	for _, c := range connectionChannels {
+		go func(c chan *amqp.Error) {
+			err, ok := <-c
+			if !ok {
+				result <- ErrUnexpectedConnClosed
+			}
+
+			result <- err
+		}(c)
+	}
+
+	// Setup monitoring for application channel
+	go func() {
+		<-stopChan
+		result <- nil
+	}()
+
+	return <-result
 }


### PR DESCRIPTION
The graceful shutdown works exactly like for the server and is moved to the connection file for easy re-use. However since it's only the publisher running that's being stopped I haven't really added waiting for what's on the publishing or responses channels. I added a comment in the client code:

```
amqpChannel := conn.NotifyClose(make(chan *amqp.Error))                                                                
err = monitorChannels(c.stopChan, []chan *amqp.Error{amqpChannel})                                                     
                                                                                                                       
// If the user calls Stop() but then starts to use the client again we must ensure that a new connection will be setup.
c.publisherRunning = false                                                                                             
                                                                                                                       
// There's not really a need to ensure that te requests chan has published                                             
// all it's messages or that the responses for a given request is received                                             
// since the send function which will add messages to the queue are                                                    
// blocking until the response has arrived. The only reason to check this                                              
// would be if a request was sent where a reply was not desired and the                                                
// user immediatle closed their program before the request was published. I                                            
// think this is something for the user of the client to handle.                                                       
```

Do you agree?