### PR TITLE
Request timeouts, expiration and some refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ means that the server is non blocking and can handle multiple requests at once.
 ```go
 c := NewClient("amqp://guest:guest@localhost:5672")
 
-request := NewRequest("my_endpoint").WithStringBody("My body").WithResponse(true)
+request := NewRequest("my_endpoint").WithBody("My body").WithResponse(true)
 response, err := c.Send(request)
 if err != nil {
     logger.Warn("Something went wrong", err)

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -92,7 +92,7 @@ func TestTopic(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.request, func(t *testing.T) {
-			_, err := c.Send(NewRequest(tc.request).WithStringBody(tc.request).WithExchange("amq.topic").WithResponse(false))
+			_, err := c.Send(NewRequest(tc.request).WithBody(tc.request).WithExchange("amq.topic").WithResponse(false))
 			Equal(t, err, nil)
 
 			for key, expectCalled := range tc.called {

--- a/client.go
+++ b/client.go
@@ -285,16 +285,16 @@ func (c *Client) runPublisher(outChan *amqp.Channel) {
 				replyToQueueName = c.replyToQueueName
 			}
 
-			c.debugLog("client: publishing %s", request.publishing.CorrelationId)
+			c.debugLog("client: publishing %s", request.Publishing.CorrelationId)
 
-			request.publishing.ReplyTo = replyToQueueName
+			request.Publishing.ReplyTo = replyToQueueName
 
 			err := outChan.Publish(
 				request.Exchange,
 				request.RoutingKey,
 				c.publishSettings.Mandatory,
 				c.publishSettings.Immediate,
-				request.publishing,
+				request.Publishing,
 			)
 
 			if err != nil {
@@ -307,20 +307,20 @@ func (c *Client) runPublisher(outChan *amqp.Channel) {
 					// will get an error back and should handle this manually!
 					c.errorLog(
 						"client: could not publish %s, giving up: %s",
-						request.publishing.CorrelationId, err.Error(),
+						request.Publishing.CorrelationId, err.Error(),
 					)
 					request.errChan <- err
 				} else {
 					c.errorLog(
 						"client: could not publish %s, retrying: %s",
-						request.publishing.CorrelationId, err.Error(),
+						request.Publishing.CorrelationId, err.Error(),
 					)
 
 					request.numRetries++
 					c.requests <- request
 				}
 
-				c.errorLog("client: publisher stopped because of error, %s", request.publishing.CorrelationId)
+				c.errorLog("client: publisher stopped because of error, %s", request.Publishing.CorrelationId)
 				return
 			}
 
@@ -330,7 +330,7 @@ func (c *Client) runPublisher(outChan *amqp.Channel) {
 				request.response <- nil
 			}
 
-			c.debugLog("client: did publish %s", request.publishing.CorrelationId)
+			c.debugLog("client: did publish %s", request.Publishing.CorrelationId)
 		}
 	}
 }
@@ -417,7 +417,7 @@ func (c *Client) send(r *Request) (*amqp.Delivery, error) {
 	correlationID := uuid.Must(uuid.NewV4()).String()
 
 	// Set the correlation id on the publishing.
-	r.publishing.CorrelationId = correlationID
+	r.Publishing.CorrelationId = correlationID
 
 	// This is where we get any (client) errors if they occure before we could
 	// even send the request.

--- a/client.go
+++ b/client.go
@@ -437,8 +437,8 @@ func (c *Client) send(r *Request) (*amqp.Delivery, error) {
 
 	// If a request timeout is specified, use that one, otherwise use the
 	// clients global timeout settings.
-	if r.timeout.Nanoseconds() == 0 {
-		r.timeout = c.timeout
+	if r.Timeout.Nanoseconds() == 0 {
+		r.Timeout = c.timeout
 	}
 
 	// start the timeout counting now.

--- a/client_test.go
+++ b/client_test.go
@@ -25,7 +25,7 @@ func TestClient(t *testing.T) {
 	client := NewClient("amqp://guest:guest@localhost:5672/")
 	NotEqual(t, client, nil)
 
-	request := NewRequest("myqueue").WithStringBody("client testing")
+	request := NewRequest("myqueue").WithBody("client testing")
 	response, err := client.Send(request)
 	Equal(t, err, nil)
 	Equal(t, response.Body, []byte("Got message: client testing"))
@@ -63,13 +63,13 @@ func TestReconnect(t *testing.T) {
 	conn, _ := <-connections
 	conn.Close()
 
-	_, err = client.Send(NewRequest("myqueue").WithStringBody("client testing"))
+	_, err = client.Send(NewRequest("myqueue").WithBody("client testing"))
 	NotEqual(t, err, nil)
 
 	// Ensure we're reconnected
 	time.Sleep(100 * time.Millisecond)
 
-	_, err = client.Send(NewRequest("myqueue").WithStringBody("client testing").WithResponse(false))
+	_, err = client.Send(NewRequest("myqueue").WithBody("client testing").WithResponse(false))
 	Equal(t, err != nil, false)
 }
 
@@ -88,18 +88,18 @@ func TestTimeout(t *testing.T) {
 	}{
 		// Client with timeout but no timeout on the Request.
 		{
-			client:  NewClient(clientTestURL).WithTimeout(1 * time.Microsecond),
+			client:  NewClient(clientTestURL).WithTimeout(1 * time.Millisecond),
 			request: NewRequest("myqueue"),
 		},
 		// Request with timeout but no timeout on the Client.
 		{
 			client:  NewClient(clientTestURL),
-			request: NewRequest("myqueue").WithTimeout(1 * time.Microsecond),
+			request: NewRequest("myqueue").WithTimeout(1 * time.Millisecond),
 		},
 		// Request timeout overrides the Client timeout.
 		{
 			client:  NewClient(clientTestURL).WithTimeout(10 * time.Second),
-			request: NewRequest("myqueue").WithTimeout(1 * time.Microsecond),
+			request: NewRequest("myqueue").WithTimeout(1 * time.Millisecond),
 		},
 	}
 

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -13,6 +13,7 @@ import (
 func main() {
 	c := amqprpc.NewClient("amqp://guest:guest@localhost:5672/")
 	c.WithErrorLogger(log.New(os.Stdout, "ERROR - ", log.LstdFlags).Printf)
+	c.WithDebugLogger(log.New(os.Stdout, "DEBUG - ", log.LstdFlags).Printf)
 
 	reader := bufio.NewReader(os.Stdin)
 
@@ -21,7 +22,7 @@ func main() {
 	for {
 		fmt.Print("Enter text: ")
 		text, _ := reader.ReadString('\n')
-		request := amqprpc.NewRequest("upper").WithStringBody(text)
+		request := amqprpc.NewRequest("upper").WithBody(text)
 
 		response, err := c.Send(request)
 		if err != nil {
@@ -36,7 +37,7 @@ func heartbeat(c *amqprpc.Client) {
 	for {
 		_, err := c.Send(
 			amqprpc.NewRequest("beat").
-				WithStringBody(time.Now().String()).
+				WithBody(time.Now().String()).
 				WithTimeout(100 * time.Millisecond),
 		)
 		if err != nil {

--- a/examples/fanout/main.go
+++ b/examples/fanout/main.go
@@ -34,7 +34,7 @@ func main() {
 	c := amqprpc.NewClient("amqp://guest:guest@localhost:5672/")
 	r := amqprpc.NewRequest("").
 		WithExchange("cool-exchange").
-		WithStringBody("Seding fanout").
+		WithBody("Seding fanout").
 		WithResponse(false)
 
 	_, err := c.Send(r)

--- a/examples/middlewares/main.go
+++ b/examples/middlewares/main.go
@@ -44,7 +44,7 @@ func main() {
 		func(next amqprpc.SendFunc) amqprpc.SendFunc {
 			return func(r *amqprpc.Request) (*amqp.Delivery, error) {
 				fmt.Println(">> I'm being executed before Send(), but only for ONE request!")
-				r.Headers["password"] = "i am custom"
+				r.Publishing().Headers["password"] = "i am custom"
 
 				return next(r)
 			}
@@ -67,7 +67,7 @@ func handlePassword(next amqprpc.SendFunc) amqprpc.SendFunc {
 			password = uuid.Must(uuid.NewV4()).String()
 		}
 
-		r.Headers["password"] = password
+		r.Publishing().Headers["password"] = password
 
 		// This will always run the clients send function in the end.
 		d, e := next(r)

--- a/examples/middlewares/main.go
+++ b/examples/middlewares/main.go
@@ -44,7 +44,7 @@ func main() {
 		func(next amqprpc.SendFunc) amqprpc.SendFunc {
 			return func(r *amqprpc.Request) (*amqp.Delivery, error) {
 				fmt.Println(">> I'm being executed before Send(), but only for ONE request!")
-				r.Publishing().Headers["password"] = "i am custom"
+				r.Publishing.Headers["password"] = "i am custom"
 
 				return next(r)
 			}
@@ -67,7 +67,7 @@ func handlePassword(next amqprpc.SendFunc) amqprpc.SendFunc {
 			password = uuid.Must(uuid.NewV4()).String()
 		}
 
-		r.Publishing().Headers["password"] = password
+		r.Publishing.Headers["password"] = password
 
 		// This will always run the clients send function in the end.
 		d, e := next(r)

--- a/examples/tls-server/main.go
+++ b/examples/tls-server/main.go
@@ -48,7 +48,7 @@ func handleClientUsage(ctx context.Context, rw *amqprpc.ResponseWriter, d amqp.D
 
 	c := amqprpc.NewClient("amqps://guest:guest@localhost:5671/").WithTLS(cert)
 
-	request := amqprpc.NewRequest("hello_world").WithStringBody("Sent with client")
+	request := amqprpc.NewRequest("hello_world").WithBody("Sent with client")
 	response, err := c.Send(request)
 	if err != nil {
 		logger.Printf("Something went wrong: %s", err)

--- a/logging_test.go
+++ b/logging_test.go
@@ -33,7 +33,7 @@ func TestClientLogging(t *testing.T) {
 	c.WithDebugLogger(logger.Printf)
 	c.WithErrorLogger(logger.Printf)
 
-	c.Send(NewRequest("foobar").WithTimeout(time.Microsecond))
+	c.Send(NewRequest("foobar").WithTimeout(time.Millisecond))
 
 	NotEqual(t, buf.String(), "")
 	MatchRegex(t, buf.String(), "^TEST")

--- a/request.go
+++ b/request.go
@@ -21,9 +21,9 @@ type Request struct {
 	// or just send the request without waiting.
 	Reply bool
 
-	// timeout is the time we should wait after a request is sent before
+	// Timeout is the time we should wait after a request is sent before
 	// we assume the request got lost.
-	timeout time.Duration
+	Timeout time.Duration
 
 	// Publishing is the publising that are going to be sent.
 	Publishing amqp.Publishing
@@ -87,7 +87,7 @@ func (r *Request) WithHeaders(h amqp.Table) *Request {
 // t will be rounded using the duration's Round function to the nearest
 // multiple of a millisecond. Rounding will be away from zero.
 func (r *Request) WithTimeout(t time.Duration) *Request {
-	r.timeout = t.Round(time.Millisecond)
+	r.Timeout = t.Round(time.Millisecond)
 	return r
 }
 
@@ -128,6 +128,6 @@ func (r *Request) AddMiddleware(m ClientMiddlewareFunc) *Request {
 // Is will also set the Expiration field for the Publishing so that amqp won't
 // hold on to the message in the queue after the timeout has happened.
 func (r *Request) startTimeout() <-chan time.Time {
-	r.Publishing.Expiration = fmt.Sprintf("%d", r.timeout.Nanoseconds()/1e6)
-	return time.After(r.timeout)
+	r.Publishing.Expiration = fmt.Sprintf("%d", r.Timeout.Nanoseconds()/1e6)
+	return time.After(r.Timeout)
 }

--- a/request_test.go
+++ b/request_test.go
@@ -55,31 +55,31 @@ func TestRequest(t *testing.T) {
 
 func TestRequestWriting(t *testing.T) {
 	r := NewRequest("foo")
-	Equal(t, len(r.publishing.Body), 0)
-	Equal(t, len(r.publishing.Headers), 0)
+	Equal(t, len(r.Publishing.Body), 0)
+	Equal(t, len(r.Publishing.Headers), 0)
 
 	t.Run("body writing", func(tt *testing.T) {
 		fmt.Fprintf(r, "my body is foo")
-		Equal(tt, r.publishing.Body, []byte("my body is foo"))
+		Equal(tt, r.Publishing.Body, []byte("my body is foo"))
 
 		fmt.Fprintf(r, "\nand bar")
-		Equal(tt, r.publishing.Body, []byte("my body is foo\nand bar"))
+		Equal(tt, r.Publishing.Body, []byte("my body is foo\nand bar"))
 
 		r.WithBody("overwrite")
-		Equal(tt, r.publishing.Body, []byte("overwrite"))
+		Equal(tt, r.Publishing.Body, []byte("overwrite"))
 
 		fmt.Fprintf(r, "written")
-		Equal(tt, r.publishing.Body, []byte("overwritewritten"))
+		Equal(tt, r.Publishing.Body, []byte("overwritewritten"))
 	})
 
 	t.Run("header writing", func(tt *testing.T) {
 		r.WriteHeader("foo", "bar")
-		Equal(tt, r.publishing.Headers, amqp.Table{
+		Equal(tt, r.Publishing.Headers, amqp.Table{
 			"foo": "bar",
 		})
 
 		r.WriteHeader("baz", "baa")
-		Equal(tt, r.publishing.Headers, amqp.Table{
+		Equal(tt, r.Publishing.Headers, amqp.Table{
 			"foo": "bar",
 			"baz": "baa",
 		})
@@ -87,12 +87,12 @@ func TestRequestWriting(t *testing.T) {
 		r.WithHeaders(amqp.Table{
 			"overwritten": "headers",
 		})
-		Equal(tt, r.publishing.Headers, amqp.Table{
+		Equal(tt, r.Publishing.Headers, amqp.Table{
 			"overwritten": "headers",
 		})
 
 		r.WriteHeader("baz", "foo")
-		Equal(tt, r.publishing.Headers, amqp.Table{
+		Equal(tt, r.Publishing.Headers, amqp.Table{
 			"overwritten": "headers",
 			"baz":         "foo",
 		})
@@ -101,7 +101,7 @@ func TestRequestWriting(t *testing.T) {
 
 func myMiddle(next SendFunc) SendFunc {
 	return func(r *Request) (*amqp.Delivery, error) {
-		r.Publishing().Body = []byte("middleware message")
+		r.Publishing.Body = []byte("middleware message")
 
 		return next(r)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -30,7 +30,7 @@ func TestSendWithReply(t *testing.T) {
 	defer stop()
 
 	c := NewClient(serverTestURL)
-	request := NewRequest("myqueue").WithStringBody("this is a message")
+	request := NewRequest("myqueue").WithBody("this is a message")
 	reply, err := c.Send(request)
 
 	Equal(t, err, nil)
@@ -107,7 +107,7 @@ func TestServerReconnect(t *testing.T) {
 	c := NewClient(serverTestURL)
 
 	for i := 0; i < 2; i++ {
-		message := []byte(fmt.Sprintf("this is message %v", i))
+		message := fmt.Sprintf("this is message %v", i)
 		request := NewRequest("myqueue").WithBody(message)
 		reply, err := c.Send(request)
 		Equal(t, err, nil)


### PR DESCRIPTION
Refactored Request to have the publishing just like ResponseWriter,
also added implementation for io.Writer, and WriteHeader.

Timeout will now set the Expiration field for the amqp.Publishing so
that amqp will have the correct TTL on the message. It will not send the
message to any consumers if the TTL has passed.