### PR TITLE
Convert to testify assert for tests. Closes #56

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,18 @@
 
 
 [[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/satori/go.uuid"
   packages = ["."]
@@ -14,14 +26,14 @@
   revision = "e5adc2ada8b8efff032bf61173a233d143e9318e"
 
 [[projects]]
-  name = "gopkg.in/go-playground/assert.v1"
-  packages = ["."]
-  revision = "4f4dfbc7d1c48336cf93399deae81aa9067e88af"
-  version = "v1.2.1"
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7ea43dbf63e6cc9cb6c44a748d45ae08ddfed59ff15672ee14931b2a73039ed5"
+  inputs-digest = "352b7cb57ca00ed2733d2e72a1611b87aefdc79f095567482a3fb350290330bf"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/acknowledger_test.go
+++ b/acknowledger_test.go
@@ -3,7 +3,7 @@ package amqprpc
 import (
 	"testing"
 
-	. "gopkg.in/go-playground/assert.v1"
+	"github.com/stretchr/testify/assert"
 )
 
 type mockAcknowledger struct {
@@ -28,30 +28,33 @@ func (ma *mockAcknowledger) Reject(tag uint64, requeue bool) error {
 }
 
 func TestAckAwareChannel(t *testing.T) {
-	ma := mockAcknowledger{}
-	aac := ackAwareChannel{ch: &ma, handled: false}
+	var (
+		assert = assert.New(t)
+		ma     = mockAcknowledger{}
+		aac    = ackAwareChannel{ch: &ma, handled: false}
+	)
 
 	// 1
 	aac.Ack(1, false)
 
-	Equal(t, aac.handled, true)
-	Equal(t, ma.ack, 1)
+	assert.Equal(true, aac.handled, "delivery handled")
+	assert.Equal(1, ma.ack, "1 delivery processed")
 
 	aac.handled = false
 
 	// 2
 	aac.Nack(2, false, false)
 
-	Equal(t, aac.handled, true)
-	Equal(t, ma.nack, 1)
+	assert.Equal(true, aac.handled, "delivery handled")
+	assert.Equal(1, ma.nack, "1 delivery processed")
 
 	aac.handled = false
 
 	// 3
 	aac.Reject(3, false)
 
-	Equal(t, aac.handled, true)
-	Equal(t, ma.reject, 1)
+	assert.Equal(true, aac.handled, "delivery handled")
+	assert.Equal(1, ma.reject, "1 delivery rejected")
 
 	aac.handled = false
 }

--- a/client_middleware_test.go
+++ b/client_middleware_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/streadway/amqp"
-	. "gopkg.in/go-playground/assert.v1"
+	"github.com/stretchr/testify/assert"
 )
 
 func traceClientMiddleware(ID int, b *bytes.Buffer) ClientMiddlewareFunc {
@@ -23,8 +23,9 @@ func traceClientMiddleware(ID int, b *bytes.Buffer) ClientMiddlewareFunc {
 
 func TestClientMiddlewareChain(t *testing.T) {
 	var (
-		req = NewRequest()
-		b   = bytes.Buffer{}
+		assert = assert.New(t)
+		req    = NewRequest()
+		b      = bytes.Buffer{}
 	)
 
 	mw := ClientMiddlewareChain(
@@ -41,15 +42,15 @@ func TestClientMiddlewareChain(t *testing.T) {
 
 	res, err := mw(req)
 
-	Equal(t, err, nil)
-	NotEqual(t, res, nil)
-	Equal(t, b.Bytes(), []byte("12X21"))
+	assert.Nil(err, "no errors chaining middlewares")
+	assert.NotNil(res, "result is not nil after passing through middlewares")
+	assert.Equal([]byte("12X21"), b.Bytes(), "middlewares executed in correct order")
 }
 
 func TestClientClientAddMiddlewares(t *testing.T) {
 	c := NewClient("")
 
-	Equal(t, len(c.middlewares), 0)
+	assert.Equal(t, 0, len(c.middlewares), "zero middlewares at start")
 
 	c.AddMiddleware(
 		func(n SendFunc) SendFunc {
@@ -59,5 +60,5 @@ func TestClientClientAddMiddlewares(t *testing.T) {
 		},
 	)
 
-	Equal(t, len(c.middlewares), 1)
+	assert.Equal(t, 1, len(c.middlewares), "adding middlewares working")
 }

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -3,18 +3,20 @@ package amqprpc
 import (
 	"testing"
 
-	. "gopkg.in/go-playground/assert.v1"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDialer(t *testing.T) {
+	assert := assert.New(t)
+
 	conn, err := DefaultDialer("tcp", "gone.local")
-	Equal(t, conn, nil)
-	NotEqual(t, err, nil)
+	assert.Nil(conn, "no connection for bad host")
+	assert.NotNil(err, "errors occurred")
 
 	conn, err = DefaultDialer("tcp", "localhost:5672")
-	Equal(t, err, nil)
-	NotEqual(t, conn, nil)
+	assert.Nil(err, "no error for correct hos")
+	assert.NotNil(conn, "connection exist")
 
 	conn = GetConnection()
-	NotEqual(t, conn, nil)
+	assert.NotNil(conn, "connection can be retrieved")
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	. "gopkg.in/go-playground/assert.v1"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestServerLogging(t *testing.T) {
@@ -31,8 +31,8 @@ func TestServerLogging(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	NotEqual(t, string(buf), "")
-	MatchRegex(t, string(buf), "^TEST")
+	assert.NotEqual(t, "", string(buf), "buffer contains logs")
+	assert.Contains(t, string(buf), "TEST", "logs are prefixed with TEST")
 }
 
 func TestClientLogging(t *testing.T) {
@@ -56,6 +56,6 @@ func TestClientLogging(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	NotEqual(t, string(buf), "")
-	MatchRegex(t, string(buf), "^TEST")
+	assert.NotEqual(t, "", string(buf), "buffer contains logs")
+	assert.Contains(t, string(buf), "TEST", "logs are prefixed with TEST")
 }

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -5,47 +5,43 @@ import (
 	"testing"
 
 	"github.com/streadway/amqp"
-	. "gopkg.in/go-playground/assert.v1"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestResponseWriter(t *testing.T) {
+	assert := assert.New(t)
+
 	rw := &ResponseWriter{
 		publishing: &amqp.Publishing{},
 	}
 
-	// The default values are false.
-	Equal(t, rw.immediate, false)
-	Equal(t, rw.mandatory, false)
+	assert.Equal(false, rw.immediate, "immediate starts false")
+	assert.Equal(false, rw.mandatory, "mandatory starts false")
 
-	// Setting true reflects internally.
 	rw.Immediate(true)
 	rw.Mandatory(true)
-	Equal(t, rw.immediate, true)
-	Equal(t, rw.mandatory, true)
 
-	// Setting false reflects internally.
+	assert.Equal(true, rw.immediate, "immediate is changed to true")
+	assert.Equal(true, rw.mandatory, "mandatory is changed to true")
+
 	rw.Immediate(false)
 	rw.Mandatory(false)
-	Equal(t, rw.immediate, false)
-	Equal(t, rw.mandatory, false)
 
-	// Writing to it reflects on the body.
+	assert.Equal(false, rw.immediate, "immediate are changed to false")
+	assert.Equal(false, rw.mandatory, "mandatory is changed to false")
+
 	fmt.Fprint(rw, "Foo")
-	Equal(t, rw.Publishing().Body, []byte("Foo"))
+	assert.Equal([]byte("Foo"), rw.Publishing().Body, "writing to response writer is reflected in the body")
 
-	// Writing multiple times is OK.
 	fmt.Fprint(rw, "Bar")
-	Equal(t, rw.Publishing().Body, []byte("FooBar"))
+	assert.Equal([]byte("FooBar"), rw.Publishing().Body, "writing to response writer multiple times is reflected in the body")
 
-	// Writing header will set the header of the publishing
 	rw.WriteHeader("some-header", "writing")
-	Equal(t, rw.Publishing().Headers["some-header"], "writing")
+	assert.Equal("writing", rw.Publishing().Headers["some-header"], "writing headers will set the headers of the publishing")
 
-	// Overwrite works
 	rw.WriteHeader("some-header", "writing-again")
-	Equal(t, rw.Publishing().Headers["some-header"], "writing-again")
+	assert.Equal("writing-again", rw.Publishing().Headers["some-header"], "overwriting headers will set the headers of the publishing")
 
-	// Writing other types than strings works
 	rw.WriteHeader("some-header", 1)
-	Equal(t, rw.Publishing().Headers["some-header"], 1)
+	assert.Equal(1, rw.Publishing().Headers["some-header"], "writing other types than s t rings to header works")
 }

--- a/server_middleware_test.go
+++ b/server_middleware_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/streadway/amqp"
-	. "gopkg.in/go-playground/assert.v1"
+	"github.com/stretchr/testify/assert"
 )
 
 func traceServerMiddleware(ID int) ServerMiddlewareFunc {
@@ -44,8 +44,8 @@ func TestServerMiddlewareChain(t *testing.T) {
 	}
 
 	handler(context.Background(), rWriter, amqp.Delivery{})
-	Equal(t, string(rWriter.Publishing().Body), "1234X4321")
+	assert.Equal(t, "1234X4321", string(rWriter.Publishing().Body), "middlewares are called in correct order")
 
 	unevenHandler(context.Background(), rWriter, amqp.Delivery{})
-	Equal(t, string(rWriter.Publishing().Body), "1234X4321123Y321")
+	assert.Equal(t, "1234X4321123Y321", string(rWriter.Publishing().Body), "all middlewares are called")
 }

--- a/tls_test.go
+++ b/tls_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "gopkg.in/go-playground/assert.v1"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTLS(t *testing.T) {
@@ -17,20 +17,20 @@ func TestTLS(t *testing.T) {
 		CA:   "./temp-ca.pem",
 	}
 
-	Equal(t, c.Cert, "./temp-cert.pem")
+	assert.Equal(t, "./temp-cert.pem", c.Cert, "certificate defined")
 
 	cfg := c.TLSConfig()
 
-	Equal(t, cfg.RootCAs == nil, false)
-	Equal(t, cfg == nil, false)
-	Equal(t, len(cfg.Certificates), 1)
+	assert.NotNil(t, cfg.RootCAs, "root CAs exist")
+	assert.NotNil(t, cfg, "config is not nil")
+	assert.Equal(t, 1, len(cfg.Certificates), "one certificate parsed")
 
 	c = Certificates{}
 
 	cfg = c.TLSConfig()
 
-	Equal(t, cfg == nil, false)
-	Equal(t, len(cfg.Certificates), 0)
+	assert.NotNil(t, cfg, "successfully generate TLSConfig")
+	assert.Equal(t, 0, len(cfg.Certificates), "no certificates for empty config")
 }
 
 func createFile(path, content string) {


### PR DESCRIPTION
I think testify is a nice assertion package and I wanted to remove the namespace imports anyways.