### PR TITLE
Add correlation ID to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,19 +201,22 @@ _, err := c.Send(r)
 ```
 
 Just like the server and client, your options is chainable.
+
 ```go
 r := NewRequest().
     WithBody(`{"hello":"world"}`).
     WithContentType("application/json").
-    WithContext(context.Background().
+    WithContext(context.Background()).
     WithExchange("custom.exchange").
     WithHeaders(amqp.Headers{}).
     WithResponse(true).
     WithRoutingKey("routing-key").
+    WithCorrelationID("my-unique-id").
     WithTimeout(5 * time.Second)
 ```
 
 Or use the request as an io.Writer(), like the `ResponseWriter`.
+
 ```go
 r := NewRequest()
 

--- a/request.go
+++ b/request.go
@@ -70,6 +70,14 @@ func (r *Request) WithRoutingKey(rk string) *Request {
 	return r
 }
 
+// WithCorrelationID will add/overwrite the correlation ID used for the
+// request and set it on the Publishing.
+func (r *Request) WithCorrelationID(id string) *Request {
+	r.Publishing.CorrelationId = id
+
+	return r
+}
+
 // WithContext will set the context on the request.
 func (r *Request) WithContext(ctx context.Context) *Request {
 	r.Context = ctx

--- a/request_test.go
+++ b/request_test.go
@@ -36,13 +36,14 @@ func TestRequest(t *testing.T) {
 	assert.Nil(err, "no errors sending request")
 	assert.Equal([]byte("Got message: hello request"), response.Body, "correct body returned")
 
-	// Test with exchange, headers, content type nad raw body.
+	// Test with exchange, headers, content type, correlation ID and raw body.
 	request = NewRequest().
 		WithRoutingKey("myqueue").
 		WithExchange("").
 		WithHeaders(amqp.Table{}).
 		WithResponse(false).
 		WithContentType("application/json").
+		WithCorrelationID("this-is-unique").
 		WithBody(`{"foo":"bar"}`)
 
 	response, err = client.Send(request)


### PR DESCRIPTION
It might be a good idea to allow custom correlation IDs as the
correlation ID used on amqp.Publishing. If a user wants to track a
request either in the RabbitMQ admin interface or any other way it's
nice to be able to map the ID. This ID is also used in the correlation
mapping wich means a user can be able to figure out which request we're
talking about when logging 'could not find where to reply'