### PR TITLE
Add OnStarted(f) to Client

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -17,6 +17,12 @@ var (
 	ErrTimeout = errors.New("request timed out")
 )
 
+// OnStartedFunc can be registered at Server.OnStarted(f) and
+// Client.OnStarted(f). This is used when you want to do more setup on the
+// connections and/or channels from amqp, for example setting Qos,
+// NotifyPublish etc.
+type OnStartedFunc func(inputConn, outputConn *amqp.Connection, inputChannel, outputChannel *amqp.Channel)
+
 // ExchangeDeclareSettings is the settings that will be used when a handler
 // is mapped to a fanout exchange and an exchange is declared.
 type ExchangeDeclareSettings struct {


### PR DESCRIPTION
This commit also ensures that the OnStartedFuncs is called *before* the
Client and Server starts consuming/publishing messages, to ensure
that any settings on the channels or connections are applied before the
first message.