### PR TITLE
[WIP] More control over importance and concurrenty

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -23,6 +23,13 @@ type HandlerBinding struct {
 	RoutingKey   string
 	BindHeaders  amqp.Table
 	Handler      HandlerFunc
+	WorkerCount  uint
+}
+
+// WithWorkerCount sets the maximum concurrent workers for a handler.
+func (hb HandlerBinding) WithWorkerCount(c uint) HandlerBinding {
+	hb.WorkerCount = c
+	return hb
 }
 
 // DirectBinding returns a HandlerBinding to use for direct exchanges where each


### PR DESCRIPTION
Work In Progress.

This should enable a user to limit the concurrency for certain long running handlers or handlers where there are a lot of messages to process that aren't so important.

TODO:

- [ ] Setting globally on server.
- [ ] Write tests
