### PR TITLE
Ensure the client is more fault tolerant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ go:
 
 services:
   - rabbitmq
-
+addons:
+  apt:
+    packages:
+      - rabbitmq-server
 env:
   global:
     - CC_TEST_REPORTER_ID=19911b8a2aa8aee6febf2f0d960d66b028a6c32a3aaa41a7a785434b2946c8d7

--- a/benchmarks/rpc_test.go
+++ b/benchmarks/rpc_test.go
@@ -24,6 +24,7 @@ func Benchmark(b *testing.B) {
 	time.Sleep(1 * time.Second)
 
 	c := amqprpc.NewClient(url)
+	defer c.Stop()
 
 	b.Run("WithReplies", func(b *testing.B) {
 		b.ResetTimer()

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -36,6 +36,8 @@ func TestFanout(t *testing.T) {
 	}
 
 	c := NewClient(bindingsTestURL)
+	defer c.Stop()
+
 	_, err := c.Send(NewRequest().WithExchange("fanout-exchange").WithResponse(false))
 
 	// Ensure all handlers have added to the timesCalled variable.
@@ -62,6 +64,7 @@ func TestTopic(t *testing.T) {
 
 	s := NewServer(bindingsTestURL)
 	c := NewClient(bindingsTestURL)
+	defer c.Stop()
 
 	s.Bind(TopicBinding("", "foo.#", func(ctx context.Context, rw *ResponseWriter, d amqp.Delivery) {
 		wasCalled["foo.#"] <- string(d.Body)
@@ -119,6 +122,7 @@ func TestTopic(t *testing.T) {
 func TestHeaders(t *testing.T) {
 	s := NewServer(bindingsTestURL)
 	c := NewClient(bindingsTestURL)
+	defer c.Stop()
 
 	handler := func(ctx context.Context, rw *ResponseWriter, d amqp.Delivery) {
 		fmt.Fprintf(rw, "Hello, world")

--- a/logging_test.go
+++ b/logging_test.go
@@ -48,9 +48,10 @@ func TestClientLogging(t *testing.T) {
 		_, err := c.Send(NewRequest().WithRoutingKey("foobar").WithTimeout(time.Millisecond))
 		c.Stop()
 
+		assert.Error(t, err, "did not get expected error")
 		assert.Contains(t, err.Error(), "timed out")
 
-		writer.Close()
+		_ = writer.Close()
 	}()
 
 	buf, err := ioutil.ReadAll(reader)

--- a/request_test.go
+++ b/request_test.go
@@ -24,6 +24,8 @@ func TestRequest(t *testing.T) {
 	defer stop()
 
 	client := NewClient(url)
+	defer client.Stop()
+
 	assert.NotNil(t, client, "client exist")
 
 	// Test simple form.

--- a/server_test.go
+++ b/server_test.go
@@ -31,6 +31,8 @@ func TestSendWithReply(t *testing.T) {
 	defer stop()
 
 	c := NewClient(serverTestURL)
+	defer c.Stop()
+
 	request := NewRequest().WithRoutingKey("myqueue").WithBody("this is a message")
 	reply, err := c.Send(request)
 
@@ -64,6 +66,7 @@ func TestMiddleware(t *testing.T) {
 	defer stop()
 
 	c := NewClient(serverTestURL)
+	defer c.Stop()
 
 	request := NewRequest().WithRoutingKey("allowed")
 	reply, err := c.Send(request)
@@ -91,6 +94,7 @@ func TestServerReconnect(t *testing.T) {
 	defer stop()
 
 	c := NewClient(serverTestURL)
+	defer c.Stop()
 
 	for i := 0; i < 2; i++ {
 		message := fmt.Sprintf("this is message %v", i)
@@ -99,7 +103,7 @@ func TestServerReconnect(t *testing.T) {
 		assert.Nil(t, err, "no error")
 
 		conn := <-connections
-		conn.Close()
+		_ = conn.Close()
 
 		assert.Equal(t, []byte(fmt.Sprintf("Got message: %s", message)), reply.Body, "message received after reconnect")
 	}


### PR DESCRIPTION
Changes the `DeleteWhenUnused: true` to instead use `x-expires` to
ensure the queue is deleted later instead of right away. This is so we
reuse the same queue previously created (and is's queued messages) when
we reconnect during a node failure.

Adds configurable maxRetries with a default of 10. In theory this should
ensure the client can keep re-connecting a few more times before giving
up sending the request.

.Stop() now waits for the client connections to properly shut down
before returning. This ensures that RabbitMQ won't log the "Unexpected
shutdown" logs in tests.