### PR TITLE
Make request and response (writer) interface the same (public fields)

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -13,46 +13,30 @@ write json:
 	encoder.Encode(dataObject)
 */
 type ResponseWriter struct {
-	publishing *amqp.Publishing
-	mandatory  bool
-	immediate  bool
+	Publishing *amqp.Publishing
+	Mandatory  bool
+	Immediate  bool
 }
 
 // NewResponseWriter will create a new response writer with given amqp.Publishing.
 func NewResponseWriter(p *amqp.Publishing) *ResponseWriter {
 	return &ResponseWriter{
-		publishing: p,
+		Publishing: p,
 	}
 }
 
 // Write will write the response Body of the amqp.Publishing.
 // It is safe to call Write multiple times.
 func (rw *ResponseWriter) Write(p []byte) (int, error) {
-	rw.publishing.Body = append(rw.publishing.Body, p...)
+	rw.Publishing.Body = append(rw.Publishing.Body, p...)
 	return len(p), nil
 }
 
 // WriteHeader will write a header for the specified key.
 func (rw *ResponseWriter) WriteHeader(header string, value interface{}) {
-	if rw.publishing.Headers == nil {
-		rw.publishing.Headers = map[string]interface{}{}
+	if rw.Publishing.Headers == nil {
+		rw.Publishing.Headers = map[string]interface{}{}
 	}
 
-	rw.publishing.Headers[header] = value
-}
-
-// Publishing returns the internal amqp.Publishing that are used for the
-// response, useful for modification.
-func (rw *ResponseWriter) Publishing() *amqp.Publishing {
-	return rw.publishing
-}
-
-// Mandatory sets the mandatory flag on the later amqp.Publish.
-func (rw *ResponseWriter) Mandatory(m bool) {
-	rw.mandatory = m
-}
-
-// Immediate sets the immediate flag on the later amqp.Publish.
-func (rw *ResponseWriter) Immediate(i bool) {
-	rw.immediate = i
+	rw.Publishing.Headers[header] = value
 }

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -12,36 +12,36 @@ func TestResponseWriter(t *testing.T) {
 	assert := assert.New(t)
 
 	rw := &ResponseWriter{
-		publishing: &amqp.Publishing{},
+		Publishing: &amqp.Publishing{},
 	}
 
-	assert.Equal(false, rw.immediate, "immediate starts false")
-	assert.Equal(false, rw.mandatory, "mandatory starts false")
+	assert.Equal(false, rw.Immediate, "immediate starts false")
+	assert.Equal(false, rw.Mandatory, "mandatory starts false")
 
-	rw.Immediate(true)
-	rw.Mandatory(true)
+	rw.Immediate = true
+	rw.Mandatory = true
 
-	assert.Equal(true, rw.immediate, "immediate is changed to true")
-	assert.Equal(true, rw.mandatory, "mandatory is changed to true")
+	assert.Equal(true, rw.Immediate, "immediate is changed to true")
+	assert.Equal(true, rw.Mandatory, "mandatory is changed to true")
 
-	rw.Immediate(false)
-	rw.Mandatory(false)
+	rw.Immediate = false
+	rw.Mandatory = false
 
-	assert.Equal(false, rw.immediate, "immediate are changed to false")
-	assert.Equal(false, rw.mandatory, "mandatory is changed to false")
+	assert.Equal(false, rw.Immediate, "immediate are changed to false")
+	assert.Equal(false, rw.Mandatory, "mandatory is changed to false")
 
 	fmt.Fprint(rw, "Foo")
-	assert.Equal([]byte("Foo"), rw.Publishing().Body, "writing to response writer is reflected in the body")
+	assert.Equal([]byte("Foo"), rw.Publishing.Body, "writing to response writer is reflected in the body")
 
 	fmt.Fprint(rw, "Bar")
-	assert.Equal([]byte("FooBar"), rw.Publishing().Body, "writing to response writer multiple times is reflected in the body")
+	assert.Equal([]byte("FooBar"), rw.Publishing.Body, "writing to response writer multiple times is reflected in the body")
 
 	rw.WriteHeader("some-header", "writing")
-	assert.Equal("writing", rw.Publishing().Headers["some-header"], "writing headers will set the headers of the publishing")
+	assert.Equal("writing", rw.Publishing.Headers["some-header"], "writing headers will set the headers of the publishing")
 
 	rw.WriteHeader("some-header", "writing-again")
-	assert.Equal("writing-again", rw.Publishing().Headers["some-header"], "overwriting headers will set the headers of the publishing")
+	assert.Equal("writing-again", rw.Publishing.Headers["some-header"], "overwriting headers will set the headers of the publishing")
 
 	rw.WriteHeader("some-header", 1)
-	assert.Equal(1, rw.Publishing().Headers["some-header"], "writing other types than s t rings to header works")
+	assert.Equal(1, rw.Publishing.Headers["some-header"], "writing other types than s t rings to header works")
 }

--- a/server.go
+++ b/server.go
@@ -399,7 +399,7 @@ func (s *Server) runHandler(handler HandlerFunc, deliveries <-chan amqp.Delivery
 		s.debugLog("server: got delivery on queue %v correlation id %v", queueName, delivery.CorrelationId)
 
 		rw := ResponseWriter{
-			publishing: &amqp.Publishing{
+			Publishing: &amqp.Publishing{
 				CorrelationId: delivery.CorrelationId,
 				Body:          []byte{},
 			},
@@ -428,9 +428,9 @@ func (s *Server) runHandler(handler HandlerFunc, deliveries <-chan amqp.Delivery
 
 			s.responses <- processedRequest{
 				replyTo:    delivery.ReplyTo,
-				mandatory:  rw.mandatory,
-				immediate:  rw.immediate,
-				publishing: *rw.publishing,
+				mandatory:  rw.Mandatory,
+				immediate:  rw.Immediate,
+				publishing: *rw.Publishing,
 			}
 
 			// Mark the specific delivery as finished.

--- a/server_middleware_test.go
+++ b/server_middleware_test.go
@@ -40,12 +40,12 @@ func TestServerMiddlewareChain(t *testing.T) {
 	)
 
 	rWriter := &ResponseWriter{
-		publishing: &amqp.Publishing{},
+		Publishing: &amqp.Publishing{},
 	}
 
 	handler(context.Background(), rWriter, amqp.Delivery{})
-	assert.Equal(t, "1234X4321", string(rWriter.Publishing().Body), "middlewares are called in correct order")
+	assert.Equal(t, "1234X4321", string(rWriter.Publishing.Body), "middlewares are called in correct order")
 
 	unevenHandler(context.Background(), rWriter, amqp.Delivery{})
-	assert.Equal(t, "1234X4321123Y321", string(rWriter.Publishing().Body), "all middlewares are called")
+	assert.Equal(t, "1234X4321123Y321", string(rWriter.Publishing.Body), "all middlewares are called")
 }


### PR DESCRIPTION
The fix we've talked about for a while, making the response writer fields public so we can access `.Publishing` the same way for a request and a response.